### PR TITLE
fix: use non deprecated actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,45 +1,18 @@
 on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to release'
-        required: true
-        type: string
+  workflow_run:
+    workflows: [Test]
+    types: [completed]
+    branches: [main]
+
+  workflow_dispatch: {}
 
 name: Release
 
+permissions:
+  contents: write
+
 jobs:
-  create-release:
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      version: ${{ steps.get_version.outputs.version }}
-    steps:
-      - name: Get version
-        id: get_version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.get_version.outputs.version }}
-          release_name: Release ${{ steps.get_version.outputs.version }}
-          draft: false
-          prerelease: false
-
   build-and-upload:
-    needs: create-release
     strategy:
       matrix:
         include:
@@ -121,24 +94,22 @@ jobs:
         shell: bash
 
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.artifact_name }}
-          asset_content_type: application/octet-stream
+          name: 'blUI Nightly'
+          prerelease: true
+          tag_name: tip
+          target_commitish: ${{ github.sha }}
+          files: ./${{ matrix.artifact_name }}
 
       - name: Upload Signature
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./${{ matrix.artifact_name }}.minisig
-          asset_name: ${{ matrix.artifact_name }}.minisig
-          asset_content_type: text/plain
+          name: 'blUI Nightly'
+          prerelease: true
+          tag_name: tip
+          target_commitish: ${{ github.sha }}
+          files: ./${{ matrix.artifact_name }}.minisig
 
       - name: Generate checksums
         if: runner.os == 'Linux' && matrix.target == 'x86_64-linux'
@@ -147,12 +118,10 @@ jobs:
         shell: bash
 
       - name: Upload Checksum
-        if: runner.os == 'Linux' && matrix.target == 'x86_64-linux'
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./${{ matrix.artifact_name }}.sha256
-          asset_name: ${{ matrix.artifact_name }}.sha256
-          asset_content_type: text/plain
+          name: 'blUI Nightly'
+          prerelease: true
+          tag_name: tip
+          target_commitish: ${{ github.sha }}
+          files: ./${{ matrix.artifact_name }}.sha256


### PR DESCRIPTION
Use none deprecated actions in release workflow
and release only nightlies for now.