### PR TITLE
feat: build ui through zig build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,13 +52,11 @@ jobs:
         with:
           version: 10
 
-      - name: Build UI (Linux/macOS)
-        if: runner.os != 'Windows'
-        run: nix develop --command bash -c "cd ui && pnpm install && pnpm run build"
-
-      - name: Build UI (Windows)
+      - name: Install Node.js (Windows)
         if: runner.os == 'Windows'
-        run: cd ui && pnpm install && pnpm run build
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 'lts/*'
 
       - name: Build binary (Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,9 +16,6 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - name: Test Build UI
-        run: nix develop --command bash -c "cd ui && pnpm install && pnpm run build"
-
       - name: Test Build
         run: nix develop -c zig build
 
@@ -32,9 +29,6 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - name: Test Build UI
-        run: nix develop --command bash -c "cd ui && pnpm install && pnpm run build"
-
       - name: Test Build
         run: nix develop -c zig build
 
@@ -44,6 +38,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Install Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: 'lts/*'
+
       - name: Install zig
         uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f  # v2.0.5
 
@@ -51,9 +50,6 @@ jobs:
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: 10
-
-      - name: Test Build UI
-        run: cd ui && pnpm install && pnpm run build
 
       - name: Test Build
         run: zig build

--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ minisign -Vm blUI-<platform> -P RWS1ZZW+8Lw8jDYlM1i8G7Panirg9TpHUz+Hj77wfk4/Qaxy
 ```bash
 git clone https://github.com/tobiaskohlbau/blui.git
 cd blui
-cd ui
-pnpm install
-pnpm build
-cd ..
 zig build
 ./zig-out/bin/blUI --accessCode PRINTER_ACCESS_CODE --ip PRINTER_IP --serial PRINTER_SERIAL
 ```


### PR DESCRIPTION
Use zig build in favor of manually calling pnpm
build before building the zig binary itself.

Fixes #8