### PR TITLE
feat: introduce thread pool for http server

### DIFF
--- a/pkg/http/Server.zig
+++ b/pkg/http/Server.zig
@@ -9,6 +9,8 @@ pub fn Server(comptime T: type) type {
 
         pub const Handler = *const fn (context: T, request: *std.http.Server.Request) anyerror!void;
 
+        const ConnectionList = std.array_list.Aligned(std.net.Server.Connection, null);
+
         allocator: std.mem.Allocator,
         context: T,
         port: u16,
@@ -31,22 +33,63 @@ pub fn Server(comptime T: type) type {
                 .reuse_address = true,
             });
 
+            const num_threads = 4;
+            var threads: [num_threads]std.Thread = undefined;
+            var thread_pool = try ConnectionList.initCapacity(s.allocator, 100 * num_threads);
+            var mutex = std.Thread.Mutex{};
+            var cond = std.Thread.Condition{};
+
+            for (&threads) |*t| {
+                t.* = try std.Thread.spawn(.{}, worker, .{ s, &thread_pool, &mutex, &cond });
+            }
+
             while (true) {
                 const conn = try tcp_server.accept();
 
-                var read_buffer: [8192]u8 = undefined;
-                var write_buffer: [8192]u8 = undefined;
-                var stream_reader = conn.stream.reader(&read_buffer);
-                var stream_writer = conn.stream.writer(&write_buffer);
-                const reader = stream_reader.interface();
-                const writer = &stream_writer.interface;
+                mutex.lock();
+                try thread_pool.append(s.allocator, conn);
+                cond.signal();
+                mutex.unlock();
+            }
+        }
 
-                var http_server = std.http.Server.init(reader, writer);
-
-                var req = try http_server.receiveHead();
-                errdefer {
-                    conn.stream.close();
+        fn worker(s: *Self, pool: *ConnectionList, mutex: *std.Thread.Mutex, cond: *std.Thread.Condition) void {
+            while (true) {
+                mutex.lock();
+                while (pool.items.len == 0) {
+                    cond.wait(mutex);
                 }
+                const conn = pool.pop();
+                mutex.unlock();
+
+                if (conn == null) {
+                    continue;
+                }
+
+                handleRequest(s, conn.?) catch |err| {
+                    std.log.err("Error handling request: {}", .{err});
+                };
+            }
+        }
+
+        fn handleRequest(s: *Self, conn: std.net.Server.Connection) !void {
+            defer conn.stream.close();
+
+            var read_buffer: [8192]u8 = undefined;
+            var write_buffer: [8192]u8 = undefined;
+            var stream_reader = conn.stream.reader(&read_buffer);
+            var stream_writer = conn.stream.writer(&write_buffer);
+            const reader = stream_reader.interface();
+            const writer = &stream_writer.interface;
+
+            var http_server = std.http.Server.init(reader, writer);
+
+            // Support keep-alive for HTTP/1.1
+            while (true) {
+                var req = http_server.receiveHead() catch |err| {
+                    if (err == error.EndOfStream) break; // Connection closed by client
+                    return err;
+                };
 
                 var path = req.head.target;
                 if (std.mem.findAnyPos(u8, req.head.target, 0, &.{ '?', '#' })) |pos| {
@@ -60,7 +103,11 @@ pub fn Server(comptime T: type) type {
                         try Self.defaultNotFoundHandler(s.context, &req);
                     };
                 }
-                conn.stream.close();
+
+                // Drop connection if keep alive is not requested
+                if (!req.head.keep_alive) {
+                    break;
+                }
             }
         }
     };


### PR DESCRIPTION
Implement a simple thread pool in order to handle http connections. This avoids blocking on a single connection until the complete request was processed. This additionally enables us to support keep-alive requests, where a underlying tcp connection it kept alive after an individual http request.

Fixes #11