### PR TITLE
feat: enable aarch64 for windows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,9 @@ jobs:
           - os: windows-latest
             target: x86_64-windows
             artifact_name: blUI-windows-x86_64.exe
+          - os: windows-latest
+            target: aarch64-windows
+            artifact_name: blUI-windows-aarch64.exe
     runs-on: ${{ matrix.os }}
     needs: [tag]
     steps:


### PR DESCRIPTION
Build for aarch64 on windows in addition to x86, arm is getting used on windows too.