### PR TITLE
feat: support configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ zig build
 ./zig-out/bin/blUI --accessCode PRINTER_ACCESS_CODE --ip PRINTER_IP --serial PRINTER_SERIAL
 ```
 
+### Configuration
+
+blUI required a configuration file. The file is expected to be in ZON format and located at:
+
+- **macOS:** `$XDG_CONFIG_HOME/blui/config.zon`
+- **Linux:** `$XDG_CONFIG_HOME/blui/config.zon`
+- **Windows:** `%APPDATA%/blui/config.zon`
+
+Command-line arguments override the configuration file values.
+
+Example `config.zon`:
+
+```zon
+.{
+    .access_code = "your_printer_access_code",
+    .ip = "printer_ip_address",
+    .serial = "printer_serial_number",
+}
+```
+
 ---
 
 ## ⚙️ Compatibility

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 var log_level = std.log.default_level;
 
 const webcam = @import("webcam/main.zig");
@@ -422,6 +423,88 @@ const Config = struct {
     ip: []const u8,
     serial: []const u8,
     ca_bundle: ?std.crypto.Certificate.Bundle,
+
+    const File = struct {
+        access_code: []const u8,
+        ip: []const u8,
+        serial: []const u8,
+    };
+
+    fn getConfigPath(allocator: std.mem.Allocator) ![]const u8 {
+        switch (builtin.target.os.tag) {
+            .macos, .linux => {
+                const config_folder = std.process.getEnvVarOwned(allocator, "XDG_CONFIG_HOME") catch return error.NoXdgConfigHome;
+                defer allocator.free(config_folder);
+                return try std.fs.path.join(allocator, &.{ config_folder, "blui", "config.zon" });
+            },
+            .windows => {
+                const appdata = std.process.getEnvVarOwned(allocator, "APPDATA") catch return error.NoAppData;
+                defer allocator.free(appdata);
+                return try std.fs.path.join(allocator, &.{ appdata, "blui", "config.zon" });
+            },
+            else => return error.UnsupportedOS,
+        }
+    }
+
+    pub fn save(c: *Config, allocator: std.mem.Allocator) !void {
+        const path = try getConfigPath(allocator);
+        defer allocator.free(path);
+
+        const config_dir = std.fs.path.dirname(path);
+        if (config_dir) |dir| {
+            try std.fs.cwd().makePath(dir);
+        }
+
+        const file = try std.fs.createFileAbsolute(path, .{});
+        defer file.close();
+
+        var buf: [8192]u8 = undefined;
+        var writer = file.writer(&buf);
+
+        const config_file: File = .{
+            .access_code = c.access_code,
+            .ip = c.ip,
+            .serial = c.serial,
+        };
+        try std.zon.stringify.serialize(config_file, .{}, &writer.interface);
+
+        try writer.interface.flush();
+    }
+
+    pub fn load(c: *Config, allocator: std.mem.Allocator) !void {
+        const path = try getConfigPath(allocator);
+        defer allocator.free(path);
+
+        const file = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
+            error.FileNotFound => blk: {
+                try c.save(allocator);
+                const f = try std.fs.openFileAbsolute(path, .{});
+                break :blk f;
+            },
+            else => return err,
+        };
+        defer file.close();
+
+        var buf: [8192]u8 = undefined;
+        var reader = file.reader(&buf);
+
+        const stat = try file.stat();
+        const data = try allocator.alloc(u8, stat.size + 1);
+        defer allocator.free(data);
+        data[stat.size] = 0;
+
+        try reader.interface.readSliceAll(data[0..stat.size]);
+
+        const config_file = try std.zon.parse.fromSliceAlloc(File, allocator, data[0..stat.size :0], null, .{});
+
+        c.* = .{
+            .dev = c.dev,
+            .access_code = try allocator.dupe(u8, config_file.access_code),
+            .ip = try allocator.dupe(u8, config_file.ip),
+            .serial = try allocator.dupe(u8, config_file.serial),
+            .ca_bundle = c.ca_bundle,
+        };
+    }
 };
 
 pub fn main() !void {
@@ -441,15 +524,31 @@ pub fn main() !void {
         .ca_bundle = null,
     };
 
+    try config.load(allocator);
+
     var debug = false;
 
     var flags = Flags.init();
     try flags.add(allocator, "dev", &config.dev, false);
     try flags.add(allocator, "debug", &debug, false);
-    try flags.add(allocator, "accessCode", &config.access_code, true);
-    try flags.add(allocator, "ip", &config.ip, true);
-    try flags.add(allocator, "serial", &config.serial, true);
+    try flags.add(allocator, "accessCode", &config.access_code, false);
+    try flags.add(allocator, "ip", &config.ip, false);
+    try flags.add(allocator, "serial", &config.serial, false);
     try flags.parse(&args);
+
+    // Check required fields
+    if (config.access_code.len == 0) {
+        std.log.err("access_code is required", .{});
+        return error.MissingRequiredConfig;
+    }
+    if (config.ip.len == 0) {
+        std.log.err("ip is required", .{});
+        return error.MissingRequiredConfig;
+    }
+    if (config.serial.len == 0) {
+        std.log.err("serial is required", .{});
+        return error.MissingRequiredConfig;
+    }
 
     if (debug) {
         log_level = .debug;


### PR DESCRIPTION
In addition to parsing config values from command line arguments loading them from file is convenient. The chosen file format is zon as parsing is natively supported by zig. The configuration is expected to be in the common locations existing in the different operating systems.

Fixes #28